### PR TITLE
添加自定义代理 & 资源文件打包逻辑

### DIFF
--- a/gocodefuncs/barchart.go
+++ b/gocodefuncs/barchart.go
@@ -72,6 +72,7 @@ func BarChart(p Runner, params map[string]interface{}) *FuncResult {
 		panic(fmt.Errorf("generateChart error: %w", err))
 	}
 
+	AddStaticResource(p, f)
 	return &FuncResult{
 		Artifacts: []*Artifact{{
 			FilePath: f,

--- a/gocodefuncs/chart.go
+++ b/gocodefuncs/chart.go
@@ -102,6 +102,7 @@ func GenerateChart(p Runner, params map[string]interface{}) *FuncResult {
 		panic(fmt.Errorf("generateChart error: %w", err))
 	}
 
+	AddStaticResource(p, f)
 	return &FuncResult{
 		Artifacts: []*Artifact{{
 			FilePath: f,

--- a/gocodefuncs/piechart.go
+++ b/gocodefuncs/piechart.go
@@ -76,6 +76,7 @@ func PieChart(p Runner, params map[string]interface{}) *FuncResult {
 		panic(fmt.Errorf("generateChart error: %w", err))
 	}
 
+	AddStaticResource(p, f)
 	return &FuncResult{
 		Artifacts: []*Artifact{{
 			FilePath: f,

--- a/gocodefuncs/piechart_test.go
+++ b/gocodefuncs/piechart_test.go
@@ -6,18 +6,21 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"sync"
 	"testing"
 )
 
 type testRunner struct {
 	lastFile string
+	objects  sync.Map
 	*testing.T
 }
 
 func (t *testRunner) GetObject(name string) (interface{}, bool) {
-	return nil, false
+	return t.objects.Load(name)
 }
 func (t *testRunner) SetObject(name string, v interface{}) {
+	t.objects.Store(name, v)
 }
 func (t *testRunner) GetLastFile() string {
 	return t.lastFile

--- a/gocodefuncs/renderdom.go
+++ b/gocodefuncs/renderdom.go
@@ -56,10 +56,14 @@ func RenderDOM(p Runner, params map[string]interface{}) *FuncResult {
 	}
 
 	// 配置代理：积木块Proxy > 全局 proxy
-	options.Proxy = GetRuntimeValue(p, GlobalProxy, options.Proxy)
+	if UseGlobalValue(p, UseGlobalProxy) {
+		options.Proxy = GetRuntimeValue(p, GlobalProxy, options.Proxy)
+	}
 
 	// 配置自定义UA：积木块 > 全局
-	options.UserAgent = GetRuntimeValue(p, GlobalUserAgent, options.UserAgent)
+	if UseGlobalValue(p, UseGlobalUserAgent) {
+		options.UserAgent = GetRuntimeValue(p, GlobalUserAgent, options.UserAgent)
+	}
 
 	var lines int64
 	if lines, err = utils.FileLines(p.GetLastFile()); err != nil {

--- a/gocodefuncs/renderdom.go
+++ b/gocodefuncs/renderdom.go
@@ -17,11 +17,11 @@ import (
 )
 
 // renderURLDOM 生成单个url的domhtml
-func renderURLDOM(p Runner, u string, timeout int) (string, error) {
-	p.Debugf("render url dom: %s", u)
+func renderURLDOM(p Runner, in chromeActionsInput, timeout int) (string, error) {
+	p.Debugf("render url dom: %s", in.URL)
 
 	var html string
-	err := chromeActions(u, p.Debugf, timeout,
+	err := chromeActions(in, p.Debugf, timeout,
 		chromedp.ActionFunc(func(ctx context.Context) error {
 			node, err := dom.GetDocument().Do(ctx)
 			if err != nil {
@@ -31,7 +31,7 @@ func renderURLDOM(p Runner, u string, timeout int) (string, error) {
 			return err
 		}))
 	if err != nil {
-		return "", fmt.Errorf("renderURLDOM failed(%w): %s", err, u)
+		return "", fmt.Errorf("renderURLDOM failed(%w): %s", err, in.URL)
 	}
 
 	return html, err
@@ -54,6 +54,12 @@ func RenderDOM(p Runner, params map[string]interface{}) *FuncResult {
 	if options.Timeout == 0 {
 		options.Timeout = 30
 	}
+
+	// 配置代理：积木块Proxy > 全局 proxy
+	options.Proxy = GetRuntimeValue(p, GlobalProxy, options.Proxy)
+
+	// 配置自定义UA：积木块 > 全局
+	options.UserAgent = GetRuntimeValue(p, GlobalUserAgent, options.UserAgent)
 
 	var lines int64
 	if lines, err = utils.FileLines(p.GetLastFile()); err != nil {
@@ -92,7 +98,11 @@ func RenderDOM(p Runner, params map[string]interface{}) *FuncResult {
 				}
 
 				var html string
-				html, err = renderURLDOM(p, u, options.Timeout)
+				html, err = renderURLDOM(p, chromeActionsInput{
+					URL:       u,
+					Proxy:     options.Proxy,
+					UserAgent: options.UserAgent,
+				}, options.Timeout)
 
 				// 不管是否成功都先把数据写入
 				line, err = sjson.Set(line, options.SaveField, html)

--- a/gocodefuncs/screenshot.go
+++ b/gocodefuncs/screenshot.go
@@ -252,9 +252,10 @@ func Screenshot(p Runner, params map[string]interface{}) *FuncResult {
 					FilePath: sfn,
 					FileSize: size,
 					FileType: "image/png",
-					FileName: filepath.Base(fn),
+					FileName: filepath.Base(sfn),
 					Memo:     u,
 				})
+				AddResource(p, sfn)
 			})
 
 			return nil
@@ -268,6 +269,8 @@ func Screenshot(p Runner, params map[string]interface{}) *FuncResult {
 	if err != nil {
 		panic(fmt.Errorf("screenShot error: %w", err))
 	}
+
+	AddResourceField(p, options.SaveField)
 
 	return &FuncResult{
 		OutFile:   fn,
@@ -293,4 +296,33 @@ func UseGlobalValue(p Runner, name string) bool {
 		}
 	}
 	return false
+}
+
+//AddResourceField 在object中添加资源字段
+func AddResourceField(p Runner, field string) {
+	AddObjectSlice(p, utils.ResourceFieldsObjectName, field)
+}
+
+//AddResource 在object中添加资源列表
+func AddResource(p Runner, resource string) {
+	AddObjectSlice(p, utils.ResourcesObjectName, resource)
+}
+
+//AddStaticResource 在object中添加static资源
+func AddStaticResource(p Runner, resource string) {
+	AddObjectSlice(p, utils.StaticResourceObjectName, resource)
+}
+
+//AddObjectSlice 在object
+func AddObjectSlice(p Runner, objectName, ele string) {
+	var result []string
+	if res, ok := p.GetObject(objectName); ok {
+		if result, ok = res.([]string); !ok {
+			result = []string{}
+		}
+	} else {
+		result = []string{}
+	}
+	result = append(result, ele)
+	p.SetObject(objectName, result)
 }

--- a/gocodefuncs/screenshot_test.go
+++ b/gocodefuncs/screenshot_test.go
@@ -59,3 +59,34 @@ func Test_chromeActions(t *testing.T) {
 		})
 	}
 }
+
+func TestAddObjectSlice(t *testing.T) {
+	runner := newTestRunner(t, "")
+	type args struct {
+		p          Runner
+		objectName string
+		ele        string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "测试添加object环境",
+			args: args{
+				p:          runner,
+				objectName: "test",
+				ele:        "test1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := tt.args.p
+			AddObjectSlice(p, tt.args.objectName, tt.args.ele)
+			object, ok := p.GetObject(tt.args.objectName)
+			assert.True(t, ok)
+			assert.Equal(t, tt.args.ele, object.([]string)[0])
+		})
+	}
+}

--- a/gocodefuncs/screenshot_test.go
+++ b/gocodefuncs/screenshot_test.go
@@ -1,0 +1,61 @@
+package gocodefuncs
+
+import (
+	"github.com/chromedp/chromedp"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_chromeActions(t *testing.T) {
+	buf := []byte{}
+	type args struct {
+		in      chromeActionsInput
+		logf    func(string, ...interface{})
+		timeout int
+		actions []chromedp.Action
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "测试正常screen picture",
+			args: args{
+				in: chromeActionsInput{
+					URL: "https://www.baidu.com",
+				},
+				logf:    func(s string, i ...interface{}) {},
+				timeout: 10,
+				actions: []chromedp.Action{
+					chromedp.Sleep(time.Second * time.Duration(1)),
+					chromedp.CaptureScreenshot(&buf),
+				},
+			},
+		},
+		{
+			name: "测试自定义proxy & UA",
+			args: args{
+				in: chromeActionsInput{
+					URL:       "http://www.baidu.com",
+					Proxy:     "socks5://127.0.0.1:7890",
+					UserAgent: "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36",
+				},
+				logf:    func(s string, i ...interface{}) {},
+				timeout: 10,
+				actions: []chromedp.Action{
+					chromedp.Sleep(time.Second * time.Duration(1)),
+					chromedp.CaptureScreenshot(&buf),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := chromeActions(tt.args.in, func(s string, i ...interface{}) {}, tt.args.timeout, tt.args.actions...)
+			assert.Nil(t, err)
+			assert.NotNil(t, buf)
+			t.Logf("screenshot result: %s", buf[0:5])
+		})
+	}
+}

--- a/gocodefuncs/toExcel.go
+++ b/gocodefuncs/toExcel.go
@@ -50,6 +50,7 @@ func ToExcel(p Runner, params map[string]interface{}) *FuncResult {
 		panic(fmt.Errorf("toExcel failed: %w", err))
 	}
 
+	AddStaticResource(p, fn)
 	return &FuncResult{
 		Artifacts: []*Artifact{
 			{

--- a/gocodefuncs/tosql.go
+++ b/gocodefuncs/tosql.go
@@ -221,6 +221,7 @@ func ToSql(p Runner, params map[string]interface{}) *FuncResult {
 		})
 	}
 
+	AddStaticResource(p, fn)
 	return &FuncResult{
 		Artifacts: artifacts,
 	}

--- a/utils/net.go
+++ b/utils/net.go
@@ -37,7 +37,7 @@ func FixURL(v string) string {
 				defaultPort = true
 			}
 		}
-		if !defaultPort {
+		if !defaultPort && u.Port() != "" {
 			v += ":" + u.Port()
 		}
 

--- a/utils/resource.go
+++ b/utils/resource.go
@@ -1,0 +1,7 @@
+package utils
+
+var (
+	ResourceFieldsObjectName = "resource_fields"
+	ResourcesObjectName      = "resources"
+	StaticResourceObjectName = "static_resource"
+)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -181,3 +181,13 @@ func ExpandVarString(query string, getVar func(name string) (string, bool)) stri
 	}
 	return query
 }
+
+// Contains string contains in a slice
+func Contains(s []string, str string) bool {
+	for _, ele := range s {
+		if str == ele {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- 添加全局自定义UA & 代理配置
- Http与chromeEdp模块添加自定义UA & 代理配置
- fix url添加判断，防止url后面多出一个":"
- 修改资源打包逻辑，只打包结果中的相关文件和饼图等固定资源文件