### PR TITLE
截图修改、临时文件生成函数修改

### DIFF
--- a/gocodefuncs/piechart_test.go
+++ b/gocodefuncs/piechart_test.go
@@ -16,10 +16,6 @@ type testRunner struct {
 	*testing.T
 }
 
-func (t *testRunner) FormatResourceFieldInJson(filename string) (string, error) {
-	return filename, nil
-}
-
 func (t *testRunner) GetObject(name string) (interface{}, bool) {
 	return t.objects.Load(name)
 }

--- a/gocodefuncs/piechart_test.go
+++ b/gocodefuncs/piechart_test.go
@@ -16,6 +16,10 @@ type testRunner struct {
 	*testing.T
 }
 
+func (t *testRunner) FormatResourceFieldInJson(filename string) (string, error) {
+	return filename, nil
+}
+
 func (t *testRunner) GetObject(name string) (interface{}, bool) {
 	return t.objects.Load(name)
 }

--- a/gocodefuncs/screenshot.go
+++ b/gocodefuncs/screenshot.go
@@ -65,6 +65,8 @@ func chromeActions(in chromeActionsInput, logf func(string, ...interface{}), tim
 		chromedp.Flag("disable-setuid-sandbox", true),
 		chromedp.Flag("disable-web-security", true),
 		chromedp.Flag("disable-dev-shm-usage", true),
+		chromedp.Flag("ppapi-in-process", true),
+		chromedp.Flag("lang", "zh"),
 		chromedp.IgnoreCertErrors,
 		chromedp.NoFirstRun,
 		chromedp.NoDefaultBrowserCheck,
@@ -90,6 +92,7 @@ func chromeActions(in chromeActionsInput, logf func(string, ...interface{}), tim
 		chromedp.ActionFunc(func(cxt context.Context) error {
 			// 等待完成，要么是body出来了，要么是资源加载完成
 			ch := make(chan error, 1)
+			time.Sleep(time.Nanosecond)
 			go func(eCh chan error) {
 				err := chromedp.Navigate(in.URL).Do(cxt)
 				if err != nil {
@@ -148,7 +151,7 @@ func screenshotURL(p Runner, u string, filename string, options *ScreenshotParam
 		URL:       u,
 		Proxy:     options.Proxy,
 		UserAgent: options.UserAgent,
-	}, p.Debugf, options.Timeout, actions...)
+	}, p.Warnf, options.Timeout, actions...)
 	if err != nil {
 		return "", 0, fmt.Errorf("screenShot failed(%w): %s", err, u)
 	}

--- a/gocodefuncs/screenshot.go
+++ b/gocodefuncs/screenshot.go
@@ -36,6 +36,7 @@ type ScreenshotParam struct {
 	Proxy              string `json:"proxy,omitempty"`              // 用户自定义代理，为空时不配置
 	UserAgent          string `json:"userAgent,omitempty"`          // 用户自定义UA，为空时不配置
 	AddUrl             bool   `json:"addUrl"`                       // 在截图中展示url地址
+	AddTimeStamp       bool   `json:"AddTimeStamp"`                 // 在截图中展示时间戳
 	FilenameDependency string `json:"filenameDependency,omitempty"` // 根据哪个字段进行文件命名
 }
 
@@ -102,14 +103,14 @@ func chromeActions(in chromeActionsInput, logf func(string, ...interface{}), tim
 					}
 				}
 				// 20211219发现如果存在JS前端框架 (如vue, react...) 执行等待读取.
+				// 这里已经有数据了，没有等到渲染结果也可以进行截图，有的可能没有渲染，就是原始结果，所以直接打日志，不用报错
 				html2Low := strings.ToLower(htmlDom)
 				if strings.Contains(html2Low, "javascript") || strings.Contains(html2Low, "</script>'") {
-					err = chromedp.WaitVisible("div", chromedp.ByQuery).Do(cxt)
-					if err := chromedp.OuterHTML("html", &htmlDom).Do(cxt); err != nil {
-						log.Println("[DEBUG] fetch html failed:", err)
+					err1 := chromedp.WaitVisible("div", chromedp.ByQuery).Do(cxt)
+					if err1 = chromedp.OuterHTML("html", &htmlDom).Do(cxt); err1 != nil {
+						log.Println("[DEBUG] fetch html failed:", err1)
 					}
 				}
-
 				eCh <- err
 			}(ch)
 
@@ -154,7 +155,7 @@ func screenshotURL(p Runner, u string, filename string, options *ScreenshotParam
 
 	// 在截图中添加当前请求地址
 	if options.AddUrl == true {
-		tmp, err := AddUrlToTitle(u, buf)
+		tmp, err := AddUrlToTitle(u, buf, options.AddTimeStamp)
 		if err != nil {
 			log.Printf("add title failed for(%s): %s", u, err.Error())
 		} else {
@@ -355,7 +356,7 @@ func AddObjectSlice(p Runner, objectName, ele string) {
 }
 
 //AddUrlToTitle 通过html转换对整个screenshot截图结果进行处理，添加标题栏并在其中写入访问的url地址
-func AddUrlToTitle(url string, picBuf []byte) (result []byte, err error) {
+func AddUrlToTitle(url string, picBuf []byte, hasTimeStamp bool) (result []byte, err error) {
 	htmlPart1 := `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -416,9 +417,14 @@ func AddUrlToTitle(url string, picBuf []byte) (result []byte, err error) {
                 <div class="btn red"></div>
                 <div class="btn yellow"></div>
                 <div class="btn green"></div>
-                <div class="btn" style="margin-top: -7px;margin-left: 1%;">
+`
+	htmlTitle := `<div class="btn" style="margin-top: -7px;margin-left: 1%;">
                     <b style="color:#48576a">`
-	htmlPart2 := `</b>
+	htmlTimeStamp := `</b>
+                </div>
+                <div class="btn" style="margin-top: 2px;margin-right: 18%;float: right;">
+                    <b style="color:#48576a">`
+	htmlBase64 := `</b>
                 </div>
             </div>
             <div style="max-height:800px;overflow:hidden;">
@@ -434,8 +440,17 @@ func AddUrlToTitle(url string, picBuf []byte) (result []byte, err error) {
 	encodedBase64 := base64.StdEncoding.EncodeToString(picBuf)
 
 	// 合成新的html文件
-	html := append([]byte(htmlPart1), []byte(url)...)
-	html = append(append(append(html, []byte(htmlPart2)...), []byte(encodedBase64)...), []byte(htmlPart3)...)
+	html := append(append([]byte(htmlPart1), []byte(htmlTitle)...), []byte(url)...)
+
+	// 添加时间戳
+	if hasTimeStamp {
+		curTime := time.Now().Format(`2006-01-02 15:04:05`)
+		html = append(html, []byte(htmlTimeStamp)...)
+		html = append(html, []byte(curTime)...)
+	}
+
+	// 添加
+	html = append(append(append(html, []byte(htmlBase64)...), []byte(encodedBase64)...), []byte(htmlPart3)...)
 	var fn string
 	fn, err = utils.WriteTempFile(".html", func(f *os.File) error {
 		_, err = f.Write(html)

--- a/gocodefuncs/screenshot_test.go
+++ b/gocodefuncs/screenshot_test.go
@@ -43,7 +43,7 @@ func Test_chromeActions(t *testing.T) {
 				in: chromeActionsInput{
 					URL:       "http://www.baidu.com",
 					Proxy:     "socks5://127.0.0.1:7890",
-					UserAgent: "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36",
+					UserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Edg/91.0.864.59",
 				},
 				logf:    func(s string, i ...interface{}) {},
 				timeout: 10,

--- a/gocodefuncs/screenshot_test.go
+++ b/gocodefuncs/screenshot_test.go
@@ -97,7 +97,8 @@ func TestAddObjectSlice(t *testing.T) {
 
 func TestAddUrlToTitle(t *testing.T) {
 	type args struct {
-		url string
+		url          string
+		hasTimeStamp bool
 	}
 	tests := []struct {
 		name string
@@ -105,7 +106,11 @@ func TestAddUrlToTitle(t *testing.T) {
 	}{
 		{
 			name: "测试截图添加url地址",
-			args: args{url: `https://fofa.info`},
+			args: args{url: `https://fofa.info`, hasTimeStamp: false},
+		},
+		{
+			name: "测试截图添加url地址 & 时间戳",
+			args: args{url: `https://fofa.info`, hasTimeStamp: true},
 		},
 	}
 	for _, tt := range tests {
@@ -119,7 +124,7 @@ func TestAddUrlToTitle(t *testing.T) {
 			err := chromedp.Run(ctx, fullScreenshot(tt.args.url, 90, &buf))
 			assert.Nil(t, err)
 
-			gotResult, err := AddUrlToTitle(tt.args.url, buf)
+			gotResult, err := AddUrlToTitle(tt.args.url, buf, tt.args.hasTimeStamp)
 			assert.Nil(t, err)
 			assert.Greater(t, len(gotResult), len(buf))
 

--- a/utils/file.go
+++ b/utils/file.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 var (
@@ -109,12 +108,12 @@ func LoadFirstExistsFile(paths []string) string {
 // writeTempFile 向Temp文件夹写入文件
 // 如果writeF是nil，就只返回生成的一个临时空文件路径
 // 返回文件名和错误
-func writeTempFile(nameTemp string, writeF func(f *os.File) error) (fn string, err error) {
+func writeTempFile(ext string, writeF func(f *os.File) error) (fn string, err error) {
 	var f *os.File
-	if len(nameTemp) > 0 && !strings.Contains("*", nameTemp) {
-		nameTemp = "*" + nameTemp
+	if len(ext) > 0 && filepath.Ext(ext) == ext {
+		ext = "*" + ext
 	}
-	f, err = os.CreateTemp(os.TempDir(), nameTemp)
+	f, err = os.CreateTemp(os.TempDir(), defaultPipeTmpFilePrefix+ext)
 	if err != nil {
 		return
 	}
@@ -132,13 +131,15 @@ func writeTempFile(nameTemp string, writeF func(f *os.File) error) (fn string, e
 }
 
 // WriteTempFile 写入临时文件
+// 输入需要写入的后缀
 // 如果writeF是nil，就只返回生成的一个临时空文件路径
 // 返回文件名和错误
 func WriteTempFile(ext string, writeF func(f *os.File) error) (fn string, err error) {
-	return writeTempFile(defaultPipeTmpFilePrefix+ext, writeF)
+	return writeTempFile(ext, writeF)
 }
 
 // WriteTempFileWithName 写入临时文件，指定生成的文件名
+// 输入需要写入的文件名
 // 如果writeF是nil，就只返回生成的一个临时空文件路径
 // 返回文件名和错误
 func WriteTempFileWithName(filename string, writeF func(f *os.File) error) (fn string, err error) {

--- a/utils/file.go
+++ b/utils/file.go
@@ -108,12 +108,15 @@ func LoadFirstExistsFile(paths []string) string {
 // writeTempFile 向Temp文件夹写入文件
 // 如果writeF是nil，就只返回生成的一个临时空文件路径
 // 返回文件名和错误
-func writeTempFile(ext string, writeF func(f *os.File) error) (fn string, err error) {
+func writeTempFile(filename string, writeF func(f *os.File) error) (fn string, err error) {
 	var f *os.File
-	if len(ext) > 0 && filepath.Ext(ext) == ext {
-		ext = "*" + ext
+	if len(filename) > 0 && filepath.Ext(filename) == filename {
+		filename = "*" + filename
+		f, err = os.CreateTemp(os.TempDir(), defaultPipeTmpFilePrefix+filename)
+	} else {
+		f, err = os.CreateTemp(os.TempDir(), filename)
 	}
-	f, err = os.CreateTemp(os.TempDir(), defaultPipeTmpFilePrefix+ext)
+
 	if err != nil {
 		return
 	}

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -141,7 +141,7 @@ func Test_writeTempFile(t *testing.T) {
 		args args
 	}{
 		{
-			name: "根据文件名写入临时文件",
+			name: "测试写入文件",
 			args: args{
 				filename: "test.json",
 			},


### PR DESCRIPTION
1. 修改截图延时处理逻辑，将未渲染完成的图片返回
2. 修复文件生成命名函数
3. 截图添加时间戳选项