### PR TITLE
JoinFofa/Scrennshot 积木块优化

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,3 +82,5 @@ require (
 	golang.org/x/term v0.8.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/LubyRuffy/gofofa => github.com/allukaZod/gofofa v0.1.12

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/LubyRuffy/goflow
 go 1.18
 
 require (
-	github.com/LubyRuffy/gofofa v0.1.11
+	github.com/LubyRuffy/gofofa v0.1.12-0.20230417162414-e7a5222bead3
 	github.com/Ullaakut/nmap/v2 v2.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/brianvoe/gofakeit/v6 v6.16.0
@@ -29,8 +29,8 @@ require (
 	github.com/urfave/cli/v2 v2.8.1
 	github.com/weppos/publicsuffix-go v0.15.0
 	github.com/xuri/excelize/v2 v2.6.0
-	golang.org/x/net v0.0.0-20220812174116-3211cb980234
-	golang.org/x/text v0.3.7
+	golang.org/x/net v0.10.0
+	golang.org/x/text v0.9.0
 )
 
 require (
@@ -67,7 +67,7 @@ require (
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	github.com/twmb/murmur3 v1.1.6 // indirect
+	github.com/twmb/murmur3 v1.1.7 // indirect
 	github.com/vincent-petithory/dataurl v1.0.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	github.com/xuri/efp v0.0.0-20220603152613-6918739fd470 // indirect
@@ -78,7 +78,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
-	golang.org/x/sys v0.1.0 // indirect
-	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/LubyRuffy/gofofa v0.1.11
 	github.com/Ullaakut/nmap/v2 v2.2.0
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/brianvoe/gofakeit/v6 v6.16.0
 	github.com/brimdata/zed v1.3.0
 	github.com/chromedp/cdproto v0.0.0-20220620034043-93c6adfcda6a

--- a/gocodefuncs/fetchfofa.go
+++ b/gocodefuncs/fetchfofa.go
@@ -16,7 +16,8 @@ type FetchFofaParams struct {
 	Query     string
 	Size      int
 	Fields    string
-	Frequency float32 `json:"frequency"`
+	Frequency float32 `json:"frequency" dc:"请求间隔，以秒为单位"`
+	Full      bool    `json:"full" dc:"是否搜索全时间段的数据"`
 }
 
 var (
@@ -63,7 +64,7 @@ func FetchFofa(p Runner, params map[string]interface{}) *FuncResult {
 	defer cancel()
 	fofaCli.(*gofofa.Client).SetContext(ctx)
 
-	res, err = fofaCli.(*gofofa.Client).HostSearch(options.Query, options.Size, fields)
+	res, err = fofaCli.(*gofofa.Client).HostSearch(options.Query, options.Size, fields, &gofofa.SecondaryOptions{Full: options.Full})
 	if err != nil {
 		panic(fmt.Errorf("HostSearch failed: %w", err))
 	}

--- a/gocodefuncs/joinfofa.go
+++ b/gocodefuncs/joinfofa.go
@@ -69,7 +69,7 @@ func JoinFofa(p Runner, params map[string]interface{}) *FuncResult {
 
 			err := retry.Do(
 				func() error {
-					res, err = fofaCli.(*gofofa.Client).HostSearch(query, options.Size, fields)
+					res, err = fofaCli.(*gofofa.Client).HostSearch(query, options.Size, fields, &gofofa.SecondaryOptions{Full: options.Full})
 					if err != nil {
 						return fmt.Errorf("HostSearch failed: %w", err)
 					}

--- a/gocodefuncs/joinfofa_test.go
+++ b/gocodefuncs/joinfofa_test.go
@@ -1,12 +1,117 @@
 package gocodefuncs
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/LubyRuffy/gofofa"
 	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 )
 
 func TestJoinFofa(t *testing.T) {
 	assert.Equal(t, "abc.com", ExpendVarWithJsonLine(nil, "${{domain}}", `{"domain":"abc.com"}`))
 	assert.Equal(t, "", ExpendVarWithJsonLine(nil, "${{domain}}", `{"domain1":"abc.com"}`))
 	assert.Equal(t, "abc.com", ExpendVarWithJsonLine(nil, "${{a.domain}}", `{"a":{"domain":"abc.com"}}`))
+}
+
+func TestJoinFofa1(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/info/my":
+			w.Write([]byte(`{"error":false,"email":"` + r.FormValue("email") + `","fcoin":10,"isvip":true,"vip_level":1}`))
+		case "/api/v1/search/all":
+			w.Write([]byte(`{"error":false,"size":12345678,"page":1,"mode":"extended","query":"host=\"https://fofa.info\"","results":[["123.1.1.1", "443"]]}`))
+		}
+	}))
+	defer ts.Close()
+	fofaCli, _ := gofofa.NewClient(gofofa.WithURL(ts.URL))
+
+	type args struct {
+		p      Runner
+		params map[string]interface{}
+		runs   int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "测试正常请求",
+			args: args{
+				p: newTestRunner(t, `{"note":"only work once"}`),
+				params: map[string]interface{}{
+					"query":     `port="443"`,
+					"size":      10,
+					"fields":    "ip,port",
+					"frequency": 0,
+				},
+				runs: 1,
+			},
+			want: "443",
+		},
+		{
+			name: "测试请求频率超限",
+			args: args{
+				p: newTestRunner(t, `{"note":"10 runs"}`),
+				params: map[string]interface{}{
+					"query":     `port="443"`,
+					"size":      10,
+					"fields":    "ip,port",
+					"frequency": 0,
+				},
+				runs: 30,
+			},
+			want: "443",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := time.Now()
+			for i := 0; i < tt.args.runs; i++ {
+				tt.args.p.SetObject(FofaObjectName, fofaCli)
+				res := JoinFofa(tt.args.p, tt.args.params)
+				fileBytes, err := ReadFirstLineOfFile(res.OutFile)
+				assert.Nil(t, err)
+				resMap := map[string]interface{}{}
+				err = json.NewDecoder(bytes.NewReader(fileBytes)).Decode(&resMap)
+				fmt.Println(fmt.Sprintf("%d : %s", i, fileBytes))
+				assert.Nil(t, err)
+				assert.Equal(t, tt.want, resMap["port"])
+			}
+			fmt.Println(time.Now().Sub(start))
+		})
+	}
+}
+
+// ReadFirstLineOfFile 读取文件的第一行
+func ReadFirstLineOfFile(fn string) ([]byte, error) {
+	f, err := os.Open(fn)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var b [1]byte
+	var data []byte
+	for {
+		_, err = f.Read(b[:])
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return data, err
+		}
+		if b[0] == '\n' {
+			break
+		}
+		data = append(data, b[0])
+	}
+	return data, nil
 }

--- a/gocodefuncs/screenshot.go
+++ b/gocodefuncs/screenshot.go
@@ -39,7 +39,7 @@ type ScreenshotParam struct {
 	AddUrl             bool   `json:"addUrl"`                       // 在截图中展示url地址
 	AddTimeStamp       bool   `json:"AddTimeStamp"`                 // 在截图中展示时间戳
 	FilenameDependency string `json:"filenameDependency,omitempty"` // 根据哪个字段进行文件命名
-	UseBase64          bool   `json:"base64"`                       // 是否输出图片的 base64 格式
+	Base64             bool   `json:"base64"`                       // 是否输出图片的 base64 格式
 }
 
 type ScreenshotOutput struct {
@@ -214,8 +214,8 @@ func screenshotURL(p Runner, u string, filename string, options *ScreenshotParam
 
 	// 生成 base64 内容
 	var screenshotBase64 string
-	if options.UseBase64 {
-		screenshotBase64 = `ddata:image/png;base64,` + base64.StdEncoding.EncodeToString(buf)
+	if options.Base64 {
+		screenshotBase64 = `data:image/png;base64,` + base64.StdEncoding.EncodeToString(buf)
 	}
 
 	return &ScreenshotOutput{
@@ -312,7 +312,7 @@ func Screenshot(p Runner, params map[string]interface{}) *FuncResult {
 				}
 
 				// 写入 base64
-				if options.UseBase64 {
+				if options.Base64 {
 					line, err = sjson.Set(line, "screenshot.base64", screenshotOutput.ScreenshotBase64)
 				}
 

--- a/gocodefuncs/screenshot.go
+++ b/gocodefuncs/screenshot.go
@@ -239,7 +239,7 @@ func Screenshot(p Runner, params map[string]interface{}) *FuncResult {
 		options.URLField = "url"
 	}
 	if options.SaveField == "" {
-		options.SaveField = "screenshot_filepath"
+		options.SaveField = "screenshot.filepath"
 	}
 	if options.Timeout == 0 {
 		options.Timeout = 30

--- a/gocodefuncs/urlFix.go
+++ b/gocodefuncs/urlFix.go
@@ -20,7 +20,7 @@ func UrlFix(p Runner, params map[string]interface{}) *FuncResult {
 		panic(fmt.Errorf("urlFix must has a field"))
 	}
 
-	fn, err = utils.WriteTempFile("", func(f *os.File) error {
+	fn, err = utils.WriteTempFile(".json", func(f *os.File) error {
 		return utils.EachLineWithContext(p.GetContext(), p.GetLastFile(), func(line string) error {
 			v := gjson.Get(line, field).String()
 			if len(v) == 0 {

--- a/runner.go
+++ b/runner.go
@@ -460,7 +460,7 @@ func New() *PipeRunner {
 		{"ToSql", gocodefuncs.ToSql},
 		{"GenData", gocodefuncs.GenData},
 		{"URLFix", gocodefuncs.UrlFix},
-		{"RenderDOM", gocodefuncs.RenderDOM},
+		//{"RenderDOM", gocodefuncs.RenderDOM},
 		{"ScanPort", gocodefuncs.ScanPort},
 		{"ParseURL", gocodefuncs.ParseURL},
 		{"HttpRequest", gocodefuncs.HttpRequest},

--- a/runner.go
+++ b/runner.go
@@ -320,7 +320,10 @@ func (p *PipeRunner) FormatResourceFieldInJson(filename string) (fn string, err 
 			if flds, ok := p.GetObject(utils.ResourceFieldsObjectName); ok {
 				for _, fld := range flds.([]string) {
 					file := gjson.Get(line, fld).String()
-					line, _ = sjson.Set(line, fld, filepath.Base(file))
+					if file != "" {
+						// 此处存在字段被删除的情况，需要在字段没有被删除的情况下再进行文件替换
+						line, _ = sjson.Set(line, fld, filepath.Base(file))
+					}
 				}
 			}
 			f.WriteString(line + "\n")

--- a/translater/screenshot.go
+++ b/translater/screenshot.go
@@ -22,7 +22,7 @@ func screenshotHook(fi *workflowast.FuncInfo) string {
 			urlField = v
 		}
 	}
-	saveField := "screenshot_filepath"
+	saveField := "screenshot.filepath"
 	if len(fi.Params) > 1 {
 		if v := fi.Params[1].RawString(); len(v) > 0 {
 			saveField = v

--- a/translater/screenshot_test.go
+++ b/translater/screenshot_test.go
@@ -10,7 +10,7 @@ func TestLoad_screenshot(t *testing.T) {
 	assert.Equal(t,
 		`Screenshot(GetRunner(), map[string]interface{}{
 	"urlField": "host",
-	"saveField": "screenshot_filepath",
+	"saveField": "screenshot.filepath",
 	"timeout": 30,
 	"workers": 5,
 })
@@ -20,7 +20,7 @@ func TestLoad_screenshot(t *testing.T) {
 	assert.Equal(t,
 		`Screenshot(GetRunner(), map[string]interface{}{
 	"urlField": "url",
-	"saveField": "screenshot_filepath",
+	"saveField": "screenshot.filepath",
 	"timeout": 30,
 	"workers": 5,
 })
@@ -30,7 +30,7 @@ func TestLoad_screenshot(t *testing.T) {
 	assert.Equal(t,
 		`Screenshot(GetRunner(), map[string]interface{}{
 	"urlField": "url",
-	"saveField": "screenshot_filepath",
+	"saveField": "screenshot.filepath",
 	"timeout": 30,
 	"workers": 5,
 })


### PR DESCRIPTION
- JoinFofa 添加重试机制，对执行失败的查询进行三次重试
- 更新gofofa依赖，添加full=true的支撑

---

- Screenshot 添加 base64 输出选项，将图片以 url base64 的格式进行输出。
- 添加截图输出base64的选项
- 修改截图命名字段
- renderDom添加等待渲染的时间
- 修改本地dom渲染输出，修正最终输出json的字段内容

--- 
- url fix 输出文件添加 .json 后缀