### PR TITLE
添加 join fofa 最大限制

### DIFF
--- a/gocodefuncs/gendata.go
+++ b/gocodefuncs/gendata.go
@@ -12,7 +12,7 @@ func GenData(p Runner, params map[string]interface{}) *FuncResult {
 	var fn string
 	var err error
 
-	ext := ""
+	ext := ".txt"
 	var m map[string]interface{}
 	if err = json.Unmarshal([]byte(params["data"].(string)), &m); err == nil {
 		ext = ".json"

--- a/gocodefuncs/httprequest.go
+++ b/gocodefuncs/httprequest.go
@@ -115,6 +115,7 @@ func HttpRequest(p Runner, params map[string]interface{}) *FuncResult {
 	var processed int64
 
 	wp := workerpool.New(options.Workers)
+	defer wp.Stop()
 	var fn string
 	fn, err = utils.WriteTempFile(".json", func(f *os.File) error {
 		var wpErr error

--- a/gocodefuncs/joinfofa.go
+++ b/gocodefuncs/joinfofa.go
@@ -29,6 +29,15 @@ func JoinFofa(p Runner, params map[string]interface{}) *FuncResult {
 		panic(fmt.Errorf("fofa fields cannot be empty"))
 	}
 
+	// 检测允许查询的最大值
+	maxSize, ok := p.GetObject(FetchMaxSizeObjectName)
+	if !ok {
+		maxSize = DefaultFetchMaxSize
+	}
+	if options.Size > maxSize.(int) {
+		panic(fmt.Errorf("max size greater than: %d", maxSize))
+	}
+
 	fields := strings.Split(options.Fields, ",")
 
 	var lines int64

--- a/gocodefuncs/renderdom.go
+++ b/gocodefuncs/renderdom.go
@@ -103,6 +103,7 @@ func RenderDOM(p Runner, params map[string]interface{}) *FuncResult {
 	var processed int64
 
 	wp := workerpool.New(options.Workers)
+	defer wp.Stop()
 	var fn string
 	fn, err = utils.WriteTempFile(".json", func(f *os.File) error {
 		var wpErr error

--- a/gocodefuncs/renderdom_test.go
+++ b/gocodefuncs/renderdom_test.go
@@ -1,0 +1,53 @@
+package gocodefuncs
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_renderURLDOM(t *testing.T) {
+	type args struct {
+		in      chromeActionsInput
+		timeout int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "测试chatgpt dom渲染 1",
+			args: args{
+				in: chromeActionsInput{
+					URL: "https://chat.jdd966.com/#/chat/1002",
+				},
+				timeout: 30,
+			},
+			want:    "未经授权",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "测试chatgpt dom渲染 2",
+			args: args{
+				in: chromeActionsInput{
+					URL: "https://chat.novapps.com/#/chat/1002",
+				},
+				timeout: 30,
+			},
+			want:    "钉钉登录",
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestRunner(t, "")
+			got, err := renderURLDOM(p, tt.args.in, tt.args.timeout, &ScreenshotParam{Sleep: 10})
+			if !tt.wantErr(t, err, fmt.Sprintf("renderURLDOM(%v, %v, %v)", p, tt.args.in, tt.args.timeout)) {
+				return
+			}
+			assert.Containsf(t, got, tt.want, "renderURLDOM(%v, %v, %v)", p, tt.args.in, tt.args.timeout)
+		})
+	}
+}

--- a/gocodefuncs/screenshot.go
+++ b/gocodefuncs/screenshot.go
@@ -40,6 +40,7 @@ type ScreenshotParam struct {
 	AddTimeStamp       bool   `json:"AddTimeStamp"`                 // 在截图中展示时间戳
 	FilenameDependency string `json:"filenameDependency,omitempty"` // 根据哪个字段进行文件命名
 	Base64             bool   `json:"base64"`                       // 是否输出图片的 base64 格式
+	RandomPrefix       bool   `json:"randomPrefix"`                 // 是否添加随机前缀
 }
 
 type ScreenshotOutput struct {
@@ -203,9 +204,15 @@ func screenshotURL(p Runner, u string, filename string, options *ScreenshotParam
 	}
 
 	var fn string
-	if filename != "" {
+	if filename != "" && options.RandomPrefix == true {
 		// 如果指定文件名，则进行指定命名
 		fn, err = utils.WriteTempFileWithName(filename+".png", func(f *os.File) error {
+			_, err = f.Write(buf)
+			return err
+		})
+	} else if filename != "" && options.RandomPrefix == false {
+		// 指定文件名，且不添加随机前缀
+		fn, err = utils.WriteTempFileWithNameOnly(filename+".png", func(f *os.File) error {
 			_, err = f.Write(buf)
 			return err
 		})

--- a/gocodefuncs/screenshot.go
+++ b/gocodefuncs/screenshot.go
@@ -271,6 +271,7 @@ func Screenshot(p Runner, params map[string]interface{}) *FuncResult {
 	var processed int64
 
 	wp := workerpool.New(options.Workers)
+	defer wp.Stop()
 	var fn string
 	fn, err = utils.WriteTempFile(".json", func(f *os.File) error {
 		var wpErr error

--- a/gocodefuncs/screenshot.go
+++ b/gocodefuncs/screenshot.go
@@ -92,7 +92,12 @@ func chromeActions(in chromeActionsInput, logf func(string, ...interface{}), tim
 	}
 
 	allocCtx, bcancel := chromedp.NewExecAllocator(context.Background(), opts...)
-	defer bcancel()
+	defer func() {
+		bcancel()
+		// linux系统不会主动关闭无头浏览器，需要手动进行关闭，否则会造成内存泄漏
+		b := chromedp.FromContext(allocCtx).Browser
+		b.Process().Signal(os.Kill)
+	}()
 
 	ctx, cancel := chromedp.NewContext(allocCtx, chromedp.WithLogf(logf))
 	ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)

--- a/gocodefuncs/textclassify.go
+++ b/gocodefuncs/textclassify.go
@@ -39,12 +39,12 @@ func TextClassify(p Runner, params map[string]interface{}) *FuncResult {
 	}
 	var regexFilterList []regItem
 	for i := range options.Filters {
-		r, err := regexp.Compile(options.Filters[i][1])
+		r, err := regexp.Compile(options.Filters[i][0])
 		if err != nil {
 			panic(fmt.Errorf("TextClassify failed: regex is not valid: %s", options.Filters[i][1]))
 		}
 		regexFilterList = append(regexFilterList, regItem{
-			Tag:    options.Filters[i][0],
+			Tag:    options.Filters[i][1],
 			Regexp: r,
 		})
 	}

--- a/runner.go
+++ b/runner.go
@@ -118,7 +118,7 @@ func (p *PipeRunner) Run(ctx context.Context, code string) (reflect.Value, error
 	p.HasResult = !p.LastFileEmpty()
 	p.doWebHook(map[string]interface{}{
 		"event": "finished",
-		"cost":  time.Since(s).String(),
+		"cost":  time.Since(s).Truncate(time.Millisecond).String(),
 		"tasks": p.Tasks,
 	})
 	return v, err

--- a/runner.go
+++ b/runner.go
@@ -8,6 +8,8 @@ import (
 	"github.com/LubyRuffy/goflow/utils"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"github.com/traefik/yaegi/interp"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -115,6 +117,9 @@ func (p *PipeRunner) Run(ctx context.Context, code string) (reflect.Value, error
 	p.content = code
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	v, err := p.gocodeRunner.Run(code)
+	if err != nil {
+		log.Println("run code failed with:\n", err.(interp.Panic).Stack)
+	}
 	p.HasResult = !p.LastFileEmpty()
 	p.doWebHook(map[string]interface{}{
 		"event": "finished",

--- a/utils/file.go
+++ b/utils/file.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var (
@@ -114,7 +115,11 @@ func writeTempFile(filename string, writeF func(f *os.File) error) (fn string, e
 		filename = "*" + filename
 		f, err = os.CreateTemp(os.TempDir(), defaultPipeTmpFilePrefix+filename)
 	} else {
-		f, err = os.CreateTemp(os.TempDir(), filename)
+		if strings.Contains(filename, "*") {
+			f, err = os.CreateTemp(os.TempDir(), filename)
+		} else {
+			f, err = os.Create(filepath.Join(os.TempDir(), filename))
+		}
 	}
 
 	if err != nil {
@@ -139,6 +144,14 @@ func writeTempFile(filename string, writeF func(f *os.File) error) (fn string, e
 // 返回文件名和错误
 func WriteTempFile(ext string, writeF func(f *os.File) error) (fn string, err error) {
 	return writeTempFile(ext, writeF)
+}
+
+// WriteTempFileWithNameOnly 写入临时文件
+// 输入文件名称
+// 如果writeF是nil，就只返回生成的一个临时空文件路径
+// 返回文件名和错误
+func WriteTempFileWithNameOnly(filename string, writeF func(f *os.File) error) (fn string, err error) {
+	return writeTempFile(filename, writeF)
 }
 
 // WriteTempFileWithName 写入临时文件，指定生成的文件名

--- a/utils/file.go
+++ b/utils/file.go
@@ -111,7 +111,7 @@ func LoadFirstExistsFile(paths []string) string {
 // 返回文件名和错误
 func writeTempFile(filename string, writeF func(f *os.File) error) (fn string, err error) {
 	var f *os.File
-	if len(filename) > 0 && filepath.Ext(filename) == filename {
+	if len(filename) > 0 && filepath.Ext(filename) == filename || filename == "" {
 		filename = "*" + filename
 		f, err = os.CreateTemp(os.TempDir(), defaultPipeTmpFilePrefix+filename)
 	} else {

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -172,6 +173,18 @@ func Test_writeTempFile(t *testing.T) {
 			assert.FileExists(t, fn)
 			fn = filepath.Base(fn)
 			match, err = regexp.Match(`\d+_test.json`, []byte(fn))
+			assert.Nil(t, err)
+			assert.Truef(t, match, fmt.Sprintf("unmatched filename: %s", fn))
+
+			// 只根据文件名写入文件，不添加随机前缀
+			fn, err = WriteTempFileWithNameOnly(tt.args.filename, func(f *os.File) error {
+				_, err = f.Write(buf)
+				return err
+			})
+			assert.Nil(t, err)
+			assert.FileExists(t, fn)
+			fn = filepath.Base(fn)
+			match = strings.EqualFold(fn, tt.args.filename)
 			assert.Nil(t, err)
 			assert.Truef(t, match, fmt.Sprintf("unmatched filename: %s", fn))
 		})


### PR DESCRIPTION
- 添加 join fofa 最大限制，与fetch fofa 相同
- 格式化执行时间，显示最小值为毫秒
- [修复textclassify key/value位置](https://github.com/LubyRuffy/goflow/commit/1f2bea730608349dd3142b62f4a5ac7d1954750a)
- [修复chromeproxy内存泄漏问题](https://github.com/LubyRuffy/goflow/pull/9/commits/fceb2c64f0a123311b45dc5efd8beb51ba4ebad0)
- [添加在临时目录按文件名写入的函数](https://github.com/LubyRuffy/goflow/pull/9/commits/389a1db6af2c19f7069c6f0c8582fc3998b8d546)
- [Screenshot模块添加随机前缀选项，默认为false](https://github.com/LubyRuffy/goflow/pull/9/commits/3a3f41f7e87b71e9e84b3e7f372a57505ccca0da)